### PR TITLE
fix: add package main file with imports for history and live

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "type": "git",
     "url": "https://github.com/metricq/metricq-js.git"
   },
-  "main": "src/metricq.js",
+  "exports": {
+    "./metricq-history": "./src/metricq-history.js",
+    "./metricq-live": "./src/metricq-live.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --progress --mode=production"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "type": "git",
     "url": "https://github.com/metricq/metricq-js.git"
   },
+  "main": "./src/metricq.js",
   "exports": {
+    ".": "./src/metricq.js",
     "./metricq-history": "./src/metricq-history.js",
     "./metricq-live": "./src/metricq-live.js"
   },

--- a/src/metricq.js
+++ b/src/metricq.js
@@ -1,0 +1,4 @@
+import MetricQHistory from './metricq-history.js'
+import MetricQLive from './metricq-live.js'
+
+export { MetricQLive, MetricQHistory }


### PR DESCRIPTION
`package.json` defines `src/metricq.js` as main file, when using `metricq-js` as node package. This PR adds this missing file