### PR TITLE
fix: pass axios config to query object

### DIFF
--- a/src/metricq-history.js
+++ b/src/metricq-history.js
@@ -46,7 +46,7 @@ class Query {
         'targets': this.targets
       }
 
-      axios.post(`${this.mq.url}/query`, paramters, this.config).then(result =>
+      axios.post(`${this.mq.url}/query`, paramters, this.mq.config).then(result =>
         resolve(this._parse_result(result))
       ).catch(error => reject(error)
       )


### PR DESCRIPTION
I forgot the `mq` to use the axios config from `MetricQHistory` in `Query.run` object in #13 🤦 